### PR TITLE
Fixed window.addEventListener('resize', resize);

### DIFF
--- a/snow.js
+++ b/snow.js
@@ -95,5 +95,5 @@ for (i = 0; i <= snowMax; i++) {
 	document.write("<span id='flake" + i + "' style='" + snowStyles + "position:absolute;top:-" + snowMaxSize + "'>" + snowEntity + "</span>");
 }
 
-wwindow.addEventListener('resize', resize);
+window.addEventListener('resize', resize);
 window.addEventListener('load', initSnow);


### PR DESCRIPTION
Fixed `window.addEventListener('resize', resize);` first was `wwindow.addEventListener('resize', resize);` now is `window.addEventListener('resize', resize);`... there was a 'w' letter to much...